### PR TITLE
Upgrade to latest Spring Data Geode

### DIFF
--- a/gemfire-app-dependencies/pom.xml
+++ b/gemfire-app-dependencies/pom.xml
@@ -1,67 +1,147 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.springframework.cloud.stream.app</groupId>
-    <artifactId>gemfire-app-dependencies</artifactId>
-    <version>2.0.0.BUILD-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <name>gemfire-app-dependencies</name>
-    <description>Spring Cloud Stream Gemfire App Dependencies</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.cloud.stream.app</groupId>
+	<artifactId>gemfire-app-dependencies</artifactId>
+	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>gemfire-app-dependencies</name>
+	<description>Spring Cloud Stream Gemfire App Dependencies</description>
 
-    <parent>
-	<artifactId>spring-cloud-dependencies-parent</artifactId>
-        <groupId>org.springframework.cloud</groupId>
-        <version>2.0.0.BUILD-SNAPSHOT</version>
-        <relativePath />
-    </parent>
+	<parent>
+		<artifactId>spring-cloud-dependencies-parent</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<relativePath/>
+	</parent>
 
-    <properties>
-        <sshd-core.version>0.10.1</sshd-core.version>
-		<gemfire.version>8.2.3</gemfire.version>
-    </properties>
+	<properties>
+		<!--<geode.version>1.4.0</geode.version>-->
+		<spring-data-geode.version>2.0.3.RELEASE</spring-data-geode.version>
+		<fast.classpath.scanner.version>2.0.21</fast.classpath.scanner.version>
+		<spring-integration.version>5.0.1.RELEASE</spring-integration.version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-source-gemfire</artifactId>
-                <version>2.0.0.BUILD-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-source-gemfire-cq</artifactId>
-                <version>2.0.0.BUILD-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-sink-gemfire</artifactId>
-                <version>2.0.0.BUILD-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-common-gemfire</artifactId>
-                <version>2.0.0.BUILD-SNAPSHOT</version>
-            </dependency>
+		<log4j.version>2.8.2</log4j.version>
+		<jline.version>2.11</jline.version>
+		<spirng.shell.version>1.2.0.RELEASE</spirng.shell.version>
+		<sshd-core.version>0.10.1</sshd-core.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Replace SpringDataGemfire by its OSS SpringDataGeode counterpart -->
+			<dependency>
+				<groupId>org.springframework.integration</groupId>
+				<artifactId>spring-integration-gemfire</artifactId>
+				<version>${spring-integration.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.springframework.data</groupId>
+						<artifactId>spring-data-gemfire</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-geode</artifactId>
+				<version>${spring-data-geode.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>io.pivotal.gemfire</groupId>
+						<artifactId>geode-core</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<!--<dependency>-->
+				<!--<groupId>org.apache.geode</groupId>-->
+				<!--<artifactId>geode-core</artifactId>-->
+				<!--<version>${geode.version}</version>-->
+			<!--</dependency>-->
+			<!--<dependency>-->
+				<!--<groupId>org.apache.geode</groupId>-->
+				<!--<artifactId>geode-cq</artifactId>-->
+				<!--<version>${geode.version}</version>-->
+			<!--</dependency>-->
+			<!--<dependency>-->
+				<!--<groupId>org.apache.geode</groupId>-->
+				<!--<artifactId>geode-wan</artifactId>-->
+				<!--<version>${geode.version}</version>-->
+			<!--</dependency>-->
+			<!--<dependency>-->
+				<!--<groupId>org.apache.geode</groupId>-->
+				<!--<artifactId>geode-lucene</artifactId>-->
+				<!--<version>${geode.version}</version>-->
+			<!--</dependency>-->
+
+			<dependency>
+				<groupId>io.github.lukehutch</groupId>
+				<artifactId>fast-classpath-scanner</artifactId>
+				<version>${fast.classpath.scanner.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.shell</groupId>
+				<artifactId>spring-shell</artifactId>
+				<version>${spirng.shell.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>jline</groupId>
+				<artifactId>jline</artifactId>
+				<version>${jline.version}</version>
+			</dependency>
+
+			<!-- Downgrades log4j/slf4 because of Gemfire/Geode hardcoded dependencies -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>${log4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>${log4j.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-source-gemfire</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-source-gemfire-cq</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-sink-gemfire</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-common-gemfire</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-test-support</artifactId>
-				<version>1.3.0.RELEASE</version>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
 			</dependency>
-            <dependency>
-                <groupId>org.apache.sshd</groupId>
-                <artifactId>sshd-core</artifactId>
-                <version>${sshd-core.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>gemfire-app-starters-test-support</artifactId>
-                <version>2.0.0.BUILD-SNAPSHOT</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-<profiles>
+			<dependency>
+				<groupId>org.apache.sshd</groupId>
+				<artifactId>sshd-core</artifactId>
+				<version>${sshd-core.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>gemfire-app-starters-test-support</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/gemfire-app-dependencies/pom.xml
+++ b/gemfire-app-dependencies/pom.xml
@@ -18,9 +18,9 @@
 
 	<properties>
 		<!--<geode.version>1.4.0</geode.version>-->
-		<spring-data-geode.version>2.0.3.RELEASE</spring-data-geode.version>
+		<spring-data-geode.version>2.0.5.RELEASE</spring-data-geode.version>
 		<fast.classpath.scanner.version>2.0.21</fast.classpath.scanner.version>
-		<spring-integration.version>5.0.1.RELEASE</spring-integration.version>
+		<spring-integration.version>5.0.3.RELEASE</spring-integration.version>
 
 		<log4j.version>2.8.2</log4j.version>
 		<jline.version>2.11</jline.version>

--- a/gemfire-app-starters-test-support/pom.xml
+++ b/gemfire-app-starters-test-support/pom.xml
@@ -13,12 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-gemfire</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.gemstone.gemfire</groupId>
-            <artifactId>gemfire</artifactId>
+            <artifactId>spring-data-geode</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/ProcessUtils.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/ProcessUtils.java
@@ -31,10 +31,11 @@ import java.lang.management.RuntimeMXBean;
 import java.util.Scanner;
 import java.util.logging.Logger;
 
+import org.apache.geode.internal.util.IOUtils;
+
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import com.gemstone.gemfire.internal.util.IOUtils;
 
 /**
  * The ProcessUtils class is a utility class for working with process, or specifically instances

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>gemfire-app-starters-build</artifactId>
 	<version>2.0.0.BUILD-SNAPSHOT</version>
@@ -32,7 +33,7 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-<profiles>
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-starter-stream-common-gemfire/pom.xml
+++ b/spring-cloud-starter-stream-common-gemfire/pom.xml
@@ -1,39 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.springframework.cloud.stream.app</groupId>
-        <artifactId>gemfire-app-starters-build</artifactId>
-        <version>2.0.0.BUILD-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>org.springframework.cloud.stream.app</groupId>
+		<artifactId>gemfire-app-starters-build</artifactId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+	</parent>
 
-    <artifactId>spring-cloud-starter-stream-common-gemfire</artifactId>
+	<artifactId>spring-cloud-starter-stream-common-gemfire</artifactId>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-gemfire</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.gemstone.gemfire</groupId>
-            <artifactId>gemfire</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-core</artifactId>
-        </dependency>
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-geode</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.lukehutch</groupId>
+			<artifactId>fast-classpath-scanner</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.shell</groupId>
+			<artifactId>spring-shell</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>jline</groupId>
+			<artifactId>jline</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-core</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/JsonObjectTransformer.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/JsonObjectTransformer.java
@@ -15,12 +15,12 @@
 
 package org.springframework.cloud.stream.app.gemfire;
 
-import org.springframework.integration.transformer.MessageTransformationException;
+import org.apache.geode.pdx.JSONFormatter;
+import org.apache.geode.pdx.PdxInstance;
+import org.json.JSONException;
+import org.json.JSONObject;
 
-import com.gemstone.gemfire.pdx.JSONFormatter;
-import com.gemstone.gemfire.pdx.PdxInstance;
-import com.gemstone.org.json.JSONException;
-import com.gemstone.org.json.JSONObject;
+import org.springframework.integration.transformer.MessageTransformationException;
 
 /**
  * @author David Turanski

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientRegionConfiguration.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientRegionConfiguration.java
@@ -15,11 +15,12 @@
 
 package org.springframework.cloud.stream.app.gemfire.config;
 
-import com.gemstone.gemfire.cache.DataPolicy;
-import com.gemstone.gemfire.cache.client.ClientCache;
+import java.util.List;
+
+import org.apache.geode.cache.DataPolicy;
+
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,9 +29,6 @@ import org.springframework.data.gemfire.client.ClientCacheFactoryBean;
 import org.springframework.data.gemfire.client.ClientRegionFactoryBean;
 import org.springframework.data.gemfire.client.Interest;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
-
-import java.util.List;
 
 /**
  * Client region configuration common to Gemfire spring-cloud-stream apps. This

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolProperties.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolProperties.java
@@ -16,8 +16,7 @@
 package org.springframework.cloud.stream.app.gemfire.config;
 
 import java.net.InetSocketAddress;
-
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireRegionProperties.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireRegionProperties.java
@@ -15,7 +15,8 @@
 
 package org.springframework.cloud.stream.app.gemfire.config;
 
-import org.hibernate.validator.constraints.NotBlank;
+import javax.validation.constraints.NotBlank;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireSecurityProperties.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireSecurityProperties.java
@@ -18,10 +18,10 @@ package org.springframework.cloud.stream.app.gemfire.config;
 
 import java.util.Properties;
 
-import com.gemstone.gemfire.LogWriter;
-import com.gemstone.gemfire.distributed.DistributedMember;
-import com.gemstone.gemfire.security.AuthInitialize;
-import com.gemstone.gemfire.security.AuthenticationFailedException;
+import org.apache.geode.LogWriter;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.security.AuthInitialize;
+import org.apache.geode.security.AuthenticationFailedException;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/spring-cloud-starter-stream-sink-gemfire/pom.xml
+++ b/spring-cloud-starter-stream-sink-gemfire/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -10,19 +11,19 @@
 
 	<artifactId>spring-cloud-starter-stream-sink-gemfire</artifactId>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.cloud.stream.app</groupId>
-            <artifactId>spring-cloud-starter-stream-common-gemfire</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-gemfire</artifactId>
-        </dependency>
+	<dependencies>
 		<dependency>
-            <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-core</artifactId>
-        </dependency>
+			<groupId>org.springframework.cloud.stream.app</groupId>
+			<artifactId>spring-cloud-starter-stream-common-gemfire</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-gemfire</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.sshd</groupId>
+			<artifactId>sshd-core</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-test-support</artifactId>

--- a/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfiguration.java
@@ -15,22 +15,22 @@
 
 package org.springframework.cloud.stream.app.gemfire.sink;
 
-import com.gemstone.gemfire.cache.Region;
+import java.util.Collections;
+import javax.annotation.Resource;
+
+import org.apache.geode.cache.Region;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.app.gemfire.config.GemfireClientRegionConfiguration;
 import org.springframework.cloud.stream.app.gemfire.config.GemfirePoolConfiguration;
-import org.springframework.cloud.stream.app.gemfire.config.GemfireSecurityProperties;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.gemfire.outbound.CacheWritingMessageHandler;
 import org.springframework.messaging.MessageHandler;
-
-import javax.annotation.Resource;
-import java.util.Collections;
 
 /**
  * @author David Turanski
@@ -46,8 +46,6 @@ public class GemfireSinkConfiguration {
 	@Autowired
 	private GemfireSinkProperties config;
 
-	//NOTE: https://jira.spring.io/browse/SPR-7915 supposedly fixed in SF 4.3. So
-	//should be able to change to @Autowired at that point
 	@Resource(name = "clientRegion")
 	private Region<String, ?> region;
 

--- a/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkHandler.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkHandler.java
@@ -15,7 +15,8 @@
 
 package org.springframework.cloud.stream.app.gemfire.sink;
 
-import com.gemstone.gemfire.pdx.PdxInstance;
+import org.apache.geode.pdx.PdxInstance;
+
 import org.springframework.cloud.stream.app.gemfire.JsonObjectTransformer;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
@@ -30,18 +31,19 @@ class GemfireSinkHandler {
 	private final Boolean convertToJson;
 	private final JsonObjectTransformer transformer = new JsonObjectTransformer();
 
-	GemfireSinkHandler(MessageHandler messageHandler, Boolean convertToJson){
+	GemfireSinkHandler(MessageHandler messageHandler, Boolean convertToJson) {
 		this.messageHandler = messageHandler;
 		this.convertToJson = convertToJson;
 	}
-	public void handle(Message<?> message){
+
+	public void handle(Message<?> message) {
 		Message<?> transformedMessage = message;
 		if (convertToJson) {
 			Object payload = message.getPayload();
 
 			if (payload instanceof String) {
-				PdxInstance transformedPayload = transformer.toObject((String)payload);
-				transformedMessage =  MessageBuilder
+				PdxInstance transformedPayload = transformer.toObject((String) payload);
+				transformedMessage = MessageBuilder
 						.fromMessage(message)
 						.withPayload(transformedPayload)
 						.build();

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfigurationTests.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfigurationTests.java
@@ -17,9 +17,9 @@ package org.springframework.cloud.stream.app.gemfire.sink;
 
 import javax.annotation.Resource;
 
-import com.gemstone.gemfire.cache.Region;
-import com.gemstone.gemfire.cache.client.ClientCache;
-import com.gemstone.gemfire.cache.client.Pool;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.Pool;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,11 +28,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.app.gemfire.config.GemfireSecurityProperties;
 import org.springframework.data.gemfire.client.Interest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static junit.framework.TestCase.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author David Turanski
@@ -41,16 +41,17 @@ import static org.junit.Assert.assertEquals;
 @SpringBootTest({"gemfire.region.regionName=Stocks", "gemfire.keyExpression='key'",
 		"gemfire.pool.hostAddresses=localhost:42424", "gemfire.pool.connectType=server"})
 @EnableConfigurationProperties({GemfireSinkProperties.class, GemfireSecurityProperties.class})
+@DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
 public class GemfireSinkConfigurationTests {
 
-	@Resource(name="clientRegion")
-	private Region region;
+	@Resource(name = "clientRegion")
+	Region<String, String> region;
 
 	@Autowired
 	private ClientCache clientCache;
 
 	@Autowired
-	private  Pool pool;
+	private Pool pool;
 
 	@Autowired(required=false)
 	private Interest<?> interest;

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkIntegrationTests.java
@@ -22,10 +22,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Resource;
 
-import com.gemstone.gemfire.cache.Region;
+import org.apache.geode.cache.Region;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,7 +33,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.app.test.gemfire.process.ProcessExecutor;
 import org.springframework.cloud.stream.app.test.gemfire.process.ProcessWrapper;
 import org.springframework.cloud.stream.app.test.gemfire.process.ServerProcess;
@@ -42,6 +40,7 @@ import org.springframework.cloud.stream.app.test.gemfire.support.FileSystemUtils
 import org.springframework.cloud.stream.app.test.gemfire.support.ThreadUtils;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -56,6 +55,7 @@ import static org.junit.Assert.assertTrue;
 @SpringBootTest({"gemfire.region.regionName=Stocks", "gemfire.keyExpression='key'", "gemfire.pool.hostAddresses=localhost:42424",
 		"gemfire.pool.connectType=server"})
 @EnableConfigurationProperties(GemfireSinkProperties.class)
+@DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
 public class GemfireSinkIntegrationTests {
 
 	@Autowired
@@ -99,7 +99,7 @@ public class GemfireSinkIntegrationTests {
 	}
 
 	@Test
-	@Ignore("See https://github.com/spring-cloud/spring-cloud-stream-modules/issues/49")
+//	@Ignore("See https://github.com/spring-cloud/spring-cloud-stream-modules/issues/49")
 	public void test() {
 		gemfireSink.input().send(new GenericMessage("hello"));
 		assertThat(region.get("key"), equalTo("hello"));

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/resources/gemfire-server.xml
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/resources/gemfire-server.xml
@@ -6,8 +6,7 @@
 	   xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 	   	http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-">
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<util:properties id="gemfireProperties">
 		<prop key="name">TestServer</prop>

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/resources/gemfire-server.xml
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/resources/gemfire-server.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
+	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<util:properties id="gemfireProperties">

--- a/spring-cloud-starter-stream-source-gemfire-cq/pom.xml
+++ b/spring-cloud-starter-stream-source-gemfire-cq/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-java-dsl</artifactId>
+            <artifactId>spring-integration-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfiguration.java
@@ -15,7 +15,8 @@
 
 package org.springframework.cloud.stream.app.gemfire.cq.source;
 
-import com.gemstone.gemfire.pdx.PdxInstance;
+import org.apache.geode.pdx.PdxInstance;
+
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -24,7 +25,6 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.app.gemfire.JsonObjectTransformer;
 import org.springframework.cloud.stream.app.gemfire.config.GemfireClientCacheConfiguration;
 import org.springframework.cloud.stream.app.gemfire.config.GemfirePoolConfiguration;
-import org.springframework.cloud.stream.app.gemfire.config.GemfireSecurityProperties;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -41,7 +41,7 @@ import org.springframework.messaging.MessageChannel;
 
 /**
  * The Gemfire CQ Source provides a {@link ContinuousQueryMessageProducer} which
- * by default, emits an object of type {@link com.gemstone.gemfire.cache.query.CqEvent}.
+ * by default, emits an object of type {@link CqEvent}.
  * This is not ideal for streaming applications because it require this type to
  * be also in the consuming app's classpath. Hence, a SpEl Expression, given by the
  * property 'qcEventExpression' is used to extract required information from the
@@ -119,7 +119,7 @@ public class GemfireCqSourceConfiguration {
 		ContinuousQueryMessageProducer continuousQueryMessageProducer = new
 				ContinuousQueryMessageProducer(continuousQueryListenerContainer(),
 				config.getQuery());
-		continuousQueryMessageProducer.setExpressionPayload(config.getCqEventExpression());
+		continuousQueryMessageProducer.setPayloadExpression(config.getCqEventExpression());
 		continuousQueryMessageProducer.setOutputChannel(routerChannel());
 		return continuousQueryMessageProducer;
 	}

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/test/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfigurationTests.java
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/test/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfigurationTests.java
@@ -15,13 +15,11 @@
 
 package org.springframework.cloud.stream.app.gemfire.cq.source;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.when;
-
-import com.gemstone.gemfire.cache.client.ClientCache;
-import com.gemstone.gemfire.cache.client.Pool;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.Pool;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +27,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.gemfire.listener.ContinuousQueryListenerContainer;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author David Turanski

--- a/spring-cloud-starter-stream-source-gemfire/README.adoc
+++ b/spring-cloud-starter-stream-source-gemfire/README.adoc
@@ -49,7 +49,7 @@ $ ./mvnw clean package
 == Examples
 
 ```
-java -jar gemfire_source.jar --gemfire.cacheEventExpression=" "
+java -jar ./gemfire-source.jar --gemfire.region.region-name=MyRegion --gemfire.cacheEventExpression="newValue"
 ```
 
 //end::ref-doc[]

--- a/spring-cloud-starter-stream-source-gemfire/pom.xml
+++ b/spring-cloud-starter-stream-source-gemfire/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-java-dsl</artifactId>
+            <artifactId>spring-integration-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.stream.app</groupId>

--- a/spring-cloud-starter-stream-source-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfigurationTests.java
+++ b/spring-cloud-starter-stream-source-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfigurationTests.java
@@ -20,10 +20,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Resource;
 
-import com.gemstone.gemfire.cache.Region;
-import com.gemstone.gemfire.cache.client.Pool;
+import org.apache.geode.cache.client.Pool;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -31,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.app.test.gemfire.process.ProcessExecutor;
@@ -41,6 +39,7 @@ import org.springframework.cloud.stream.app.test.gemfire.support.FileSystemUtils
 import org.springframework.cloud.stream.app.test.gemfire.support.ThreadUtils;
 import org.springframework.cloud.stream.test.binder.TestSupportBinderAutoConfiguration;
 import org.springframework.data.gemfire.client.Interest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,14 +50,12 @@ import static org.junit.Assert.assertTrue;
  **/
 @RunWith(SpringJUnit4ClassRunner.class)
 
-@SpringBootTest(classes = {GemfireSourceConfiguration.class,
+@SpringBootTest(classes = { GemfireSourceConfiguration.class,
 		PropertyPlaceholderAutoConfiguration.class,
-		TestSupportBinderAutoConfiguration.class}, value = { "gemfire.region.regionName=Stocks"})
+		TestSupportBinderAutoConfiguration.class }, value = { "gemfire.region.regionName=Stocks" })
 @EnableConfigurationProperties(GemfireSourceProperties.class)
+@DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
 public class GemfireSourceConfigurationTests {
-
-	@Resource(name = "clientRegion")
-	private Region region;
 
 	@Autowired
 	private Pool pool;
@@ -67,7 +64,6 @@ public class GemfireSourceConfigurationTests {
 	private List<Interest> interests;
 
 	private static ProcessWrapper serverProcess;
-
 
 	@BeforeClass
 	public static void setup() throws IOException {
@@ -101,14 +97,12 @@ public class GemfireSourceConfigurationTests {
 		});
 	}
 
-
 	@Test
 	@Ignore("No Subscription Servers available")
-	public void testDefaultConfiguration() throws InterruptedException {
+	public void testDefaultConfiguration() {
 		assertThat("interests not present", interests.size() >= 1);
 		assertThat("subscriptions should be enabled", pool.getSubscriptionEnabled());
 	}
-
 
 	@AfterClass
 	public static void tearDown() {


### PR DESCRIPTION
Resolves #9
- Update from Gemfire 8.2.3 to Spring Data Geode 2.0.3 (which pulls Geode 1.2.1)
- Resolve a log4j and slf4j version conflict SpringBoot2 - downgrade log4j from 2.10.0 to 2.8.2
- Fix the Gemfire Shell handling
 - Force update the gemfire-core's fast-classpath-scanner dependecy from 2.0.11 to 2.0.21
 - Add spring-shell:1.2.0 and jline:2.11