### PR TITLE
Upgrade to Apage Geode 1.6.0 / GemFire 9.5.1

### DIFF
--- a/gemfire-app-dependencies/pom.xml
+++ b/gemfire-app-dependencies/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!--<geode.version>1.4.0</geode.version>-->
-		<spring-data-geode.version>2.0.5.RELEASE</spring-data-geode.version>
+		<spring-data-geode.version>2.1.0.RC2</spring-data-geode.version>
 		<fast.classpath.scanner.version>2.0.21</fast.classpath.scanner.version>
 		<spring-integration.version>5.0.3.RELEASE</spring-integration.version>
 


### PR DESCRIPTION
 - Upgrade Spring Data Geode to 2.1.RC2. Later in-turn upgrades to Apache Geode 1.6 release. Note that GemFire 9.5.1 == Apache Geode 1.6.0

Resolves #15