### PR TITLE
Update SDG version. Handle PDX input

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,19 @@
 
 To learn more about this application and the supported properties, please review the following link.
 
+Following table what versions of Apache Geode, Gemfire and PCC are supported by the Gemfire App releases:
+.Table Compatibility Table
+|===
+|Gemfire App Starter| Spring Data Geode  | Apache Geode |  GemFire | Supported PCC |
+
+|2.1.1.RELEASE
+|2.1.5.RELEASE
+|1.6.x and higher
+|9.5.x and higher
+|PCC 1.5 / PCC 1.6
+|===
+
+
 ## Gemfire Sources
 include::spring-cloud-starter-stream-source-gemfire/README.adoc[]
 

--- a/gemfire-app-dependencies/pom.xml
+++ b/gemfire-app-dependencies/pom.xml
@@ -17,16 +17,15 @@
 	</parent>
 
 	<properties>
-		<!--<geode.version>1.4.0</geode.version>-->
-		<spring-data-geode.version>2.1.0.RELEASE</spring-data-geode.version>
+		<!--<geode.version>1.8.0</geode.version>-->
+		<spring-data-geode.version>2.1.5.RELEASE</spring-data-geode.version>
 		<fast.classpath.scanner.version>2.0.21</fast.classpath.scanner.version>
-		<spring-integration.version>5.0.3.RELEASE</spring-integration.version>
+		<spring-integration.version>5.1.3.RELEASE</spring-integration.version>
 
 		<log4j.version>2.8.2</log4j.version>
 		<jline.version>2.11</jline.version>
 		<spirng.shell.version>1.2.0.RELEASE</spirng.shell.version>
 		<sshd-core.version>0.10.1</sshd-core.version>
-		<spring-cloud-stream.version>2.0.0.RELEASE</spring-cloud-stream.version>
 	</properties>
 
 	<dependencyManagement>
@@ -122,11 +121,6 @@
 				<groupId>org.springframework.cloud.stream.app</groupId>
 				<artifactId>spring-cloud-starter-stream-common-gemfire</artifactId>
 				<version>2.1.1.BUILD-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-test-support</artifactId>
-				<version>${spring-cloud-stream.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.sshd</groupId>

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientCacheConfiguration.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientCacheConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 the original author or authors.
+ * Copyright (c) 2016-2019 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License") ;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,6 +20,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
@@ -32,7 +34,8 @@ import org.springframework.util.StringUtils;
  * @author David Turanski
  * @author Christian Tzolov
  */
-@EnableConfigurationProperties({ GemfireSecurityProperties.class, GemfireSslProperties.class })
+@EnableConfigurationProperties({ GemfireClientCacheProperties.class, GemfireSecurityProperties.class,
+		GemfireSslProperties.class })
 public class GemfireClientCacheConfiguration {
 
 	private static final String SECURITY_CLIENT = "security-client-auth-init";
@@ -40,7 +43,8 @@ public class GemfireClientCacheConfiguration {
 	private static final String SECURITY_PASSWORD = "security-password";
 
 	@Bean
-	public ClientCacheFactoryBean clientCache(GemfireSecurityProperties securityProperties, GemfireSslProperties sslProperties) {
+	public ClientCacheFactoryBean clientCache(GemfireClientCacheProperties clientCacheProperties,
+			GemfireSecurityProperties securityProperties, GemfireSslProperties sslProperties) {
 		ClientCacheFactoryBean clientCacheFactoryBean = new ClientCacheFactoryBean();
 		clientCacheFactoryBean.setUseBeanFactoryLocator(false);
 		clientCacheFactoryBean.setPoolName("gemfirePool");
@@ -63,6 +67,11 @@ public class GemfireClientCacheConfiguration {
 		}
 
 		clientCacheFactoryBean.setReadyForEvents(true);
+
+		if (clientCacheProperties.isPdxReadSerialized()) {
+			clientCacheFactoryBean.setPdxSerializer(new ReflectionBasedAutoSerializer(".*"));
+			clientCacheFactoryBean.setPdxReadSerialized(true);
+		}
 
 		return clientCacheFactoryBean;
 	}

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientCacheProperties.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientCacheProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.gemfire.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Gemfire client pool configuration properties
+ *
+ * @author Christian Tzolov
+ */
+@ConfigurationProperties("gemfire.client")
+@Validated
+public class GemfireClientCacheProperties {
+
+	/**
+	 * Deserialize the Geode objects into PdxInstance instead of the domain class.
+	 */
+	private boolean pdxReadSerialized = false;
+
+	public boolean isPdxReadSerialized() {
+		return pdxReadSerialized;
+	}
+
+	public void setPdxReadSerialized(boolean pdxReadSerialized) {
+		this.pdxReadSerialized = pdxReadSerialized;
+	}
+}

--- a/spring-cloud-starter-stream-sink-gemfire/README.adoc
+++ b/spring-cloud-starter-stream-sink-gemfire/README.adoc
@@ -34,8 +34,6 @@ N/A
 The **$$gemfire$$** $$sink$$ has the following options:
 
 //tag::configuration-properties[]
-$$gemfire.json$$:: $$Indicates if the Gemfire region stores json objects as native Gemfire PdxInstance$$ *($$Boolean$$, default: `$$false$$`)*
-$$gemfire.key-expression$$:: $$SpEL expression to use as a cache key$$ *($$String$$, default: `$$<none>$$`)*
 $$gemfire.pool.connect-type$$:: $$Specifies connection type: 'server' or 'locator'.$$ *($$ConnectType$$, default: `$$<none>$$`, possible values: `locator`,`server`)*
 $$gemfire.pool.host-addresses$$:: $$Specifies one or more Gemfire locator or server addresses formatted as [host]:[port].$$ *($$InetSocketAddress[]$$, default: `$$<none>$$`)*
 $$gemfire.pool.subscription-enabled$$:: $$Set to true to enable subscriptions for the client pool. Required to sync updates to the client cache.$$ *($$Boolean$$, default: `$$false$$`)*
@@ -50,6 +48,8 @@ $$gemfire.security.ssl.truststore-type$$:: $$Identifies the type of truststore u
 $$gemfire.security.ssl.truststore-uri$$:: $$Location of the pre-created truststore URI to be used for connecting to the Geode cluster.$$ *($$Resource$$, default: `$$<none>$$`)*
 $$gemfire.security.ssl.user-home-directory$$:: $$Local directory to cache the truststore and keystore files downloaded form the truststoreUri and keystoreUri locations.$$ *($$String$$, default: `$$user.home$$`)*
 $$gemfire.security.username$$:: $$The cache username.$$ *($$String$$, default: `$$<none>$$`)*
+$$gemfire.sink.json$$:: $$Indicates if the Gemfire region stores json objects as native Gemfire PdxInstance$$ *($$Boolean$$, default: `$$false$$`)*
+$$gemfire.sink.key-expression$$:: $$SpEL expression to use as a cache key$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 == Build
@@ -67,7 +67,7 @@ $ ./mvnw clean package
 == Examples
 
 ```
-java -jar gemfire-sink.jar --gemfire.keyExpression=
+java -jar gemfire-sink.jar --gemfire.sink.keyExpression=
 ```
 
 //end::ref-doc[]

--- a/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,7 +22,7 @@ import org.springframework.validation.annotation.Validated;
 /**
  * @author David Turanski
  */
-@ConfigurationProperties("gemfire")
+@ConfigurationProperties("gemfire.sink")
 @Validated
 public class GemfireSinkProperties {
 

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfigurationTests.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfigurationTests.java
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * @author David Turanski
  **/
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(value = { "gemfire.region.regionName=Stocks", "gemfire.keyExpression='key'",
+@SpringBootTest(value = { "gemfire.region.regionName=Stocks", "gemfire.sink.keyExpression='key'",
 		"gemfire.pool.hostAddresses=localhost:42424", "gemfire.pool.connectType=server",
 		"spring.cloud.stream.default.binder=test" },
 		classes = { GemfireSinkConfiguration.class })

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/normal/GemfireSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/normal/GemfireSinkIntegrationTests.java
@@ -51,7 +51,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = { "gemfire.region.regionName=Stocks",
-				"gemfire.keyExpression='key'",
+				"gemfire.sink.keyExpression='key'",
 				"gemfire.pool.hostAddresses=localhost:42424",
 				"gemfire.pool.connectType=server",
 				"spring.cloud.stream.default.binder=test"
@@ -75,7 +75,7 @@ public abstract class GemfireSinkIntegrationTests {
 		serverProcess = GeodeServerLauncherHelper.startGeode("GemFireTestServer", "gemfire-server.xml");
 	}
 
-	@TestPropertySource(properties = { "gemfire.json=false" })
+	@TestPropertySource(properties = { "gemfire.sink.json=false" })
 	public static class GemfireSinkNonJsonModeTests extends GemfireSinkIntegrationTests {
 
 		@Test
@@ -85,7 +85,7 @@ public abstract class GemfireSinkIntegrationTests {
 		}
 	}
 
-	@TestPropertySource(properties = "gemfire.json=true")
+	@TestPropertySource(properties = "gemfire.sink.json=true")
 	public static class GemfireSinkJsonModeTests extends GemfireSinkIntegrationTests {
 
 		@Test

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/ssl/SslGemfireSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/ssl/SslGemfireSinkIntegrationTests.java
@@ -50,7 +50,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = { "gemfire.region.regionName=Stocks",
-				"gemfire.keyExpression='key'",
+				"gemfire.sink.keyExpression='key'",
 				"gemfire.pool.hostAddresses=localhost:42425",
 				"gemfire.pool.connectType=server",
 				"gemfire.security.ssl.truststoreUri=classpath:/trusted.keystore",
@@ -78,7 +78,7 @@ public abstract class SslGemfireSinkIntegrationTests {
 		serverProcess = GeodeServerLauncherHelper.startGeode("SslGemFireTestServer", "ssl-gemfire-server.xml");
 	}
 
-	@TestPropertySource(properties = { "gemfire.json=false"})
+	@TestPropertySource(properties = { "gemfire.sink.json=false"})
 	public static class GemfireSinkNonJsonModeTests extends SslGemfireSinkIntegrationTests {
 
 		@Test
@@ -88,7 +88,7 @@ public abstract class SslGemfireSinkIntegrationTests {
 		}
 	}
 
-	@TestPropertySource(properties = "gemfire.json=true")
+	@TestPropertySource(properties = "gemfire.sink.json=true")
 	public static class GemfireSinkJsonModeTests extends SslGemfireSinkIntegrationTests {
 
 		@Test

--- a/spring-cloud-starter-stream-source-gemfire-cq/README.adoc
+++ b/spring-cloud-starter-stream-source-gemfire-cq/README.adoc
@@ -28,11 +28,12 @@ N/A
 The **$$gemfire-cq$$** $$source$$ supports the following configuration properties:
 
 //tag::configuration-properties[]
-$$gemfire.cq-event-expression$$:: $$SpEL expression to use to extract data from a cq event.$$ *($$Expression$$, default: `$$<none>$$`)*
+$$gemfire.client.pdx-read-serialized$$:: $$Deserialize the Geode objects into PdxInstance instead of the domain class.$$ *($$Boolean$$, default: `$$false$$`)*
+$$gemfire.cq.event-expression$$:: $$SpEL expression to use to extract data from a cq event.$$ *($$Expression$$, default: `$$<none>$$`)*
+$$gemfire.cq.query$$:: $$The OQL query$$ *($$String$$, default: `$$<none>$$`)*
 $$gemfire.pool.connect-type$$:: $$Specifies connection type: 'server' or 'locator'.$$ *($$ConnectType$$, default: `$$<none>$$`, possible values: `locator`,`server`)*
 $$gemfire.pool.host-addresses$$:: $$Specifies one or more Gemfire locator or server addresses formatted as [host]:[port].$$ *($$InetSocketAddress[]$$, default: `$$<none>$$`)*
 $$gemfire.pool.subscription-enabled$$:: $$Set to true to enable subscriptions for the client pool. Required to sync updates to the client cache.$$ *($$Boolean$$, default: `$$false$$`)*
-$$gemfire.query$$:: $$The OQL query$$ *($$String$$, default: `$$<none>$$`)*
 $$gemfire.security.password$$:: $$The cache password.$$ *($$String$$, default: `$$<none>$$`)*
 $$gemfire.security.ssl.ciphers$$:: $$Configures the SSL ciphers used for secure Socket connections as an array of valid cipher names.$$ *($$String$$, default: `$$any$$`)*
 $$gemfire.security.ssl.keystore-type$$:: $$Identifies the type of Keystore used for SSL communications (e.g. JKS, PKCS11, etc.).$$ *($$String$$, default: `$$JKS$$`)*
@@ -60,7 +61,7 @@ $ ./mvnw clean package
 == Examples
 
 ```
-java -jar gemfire-cq-source.jar --gemfire.query=
+java -jar gemfire-cq-source.jar --gemfire.cq.query=
 ```
 
 //end::ref-doc[]

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfiguration.java
@@ -119,7 +119,7 @@ public class GemfireCqSourceConfiguration {
 		ContinuousQueryMessageProducer continuousQueryMessageProducer = new
 				ContinuousQueryMessageProducer(continuousQueryListenerContainer(),
 				config.getQuery());
-		continuousQueryMessageProducer.setPayloadExpression(config.getCqEventExpression());
+		continuousQueryMessageProducer.setPayloadExpression(config.getEventExpression());
 		continuousQueryMessageProducer.setOutputChannel(routerChannel());
 		return continuousQueryMessageProducer;
 	}

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceProperties.java
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -26,7 +26,7 @@ import org.springframework.validation.annotation.Validated;
  *
  * @author David Turanski
  */
-@ConfigurationProperties("gemfire")
+@ConfigurationProperties("gemfire.cq")
 @Validated
 public class GemfireCqSourceProperties {
 
@@ -35,7 +35,7 @@ public class GemfireCqSourceProperties {
 	/**
 	 * SpEL expression to use to extract data from a cq event.
 	 */
-	private Expression cqEventExpression = new SpelExpressionParser().parseExpression
+	private Expression eventExpression = new SpelExpressionParser().parseExpression
 			(DEFAULT_EXPRESSION);
 
 	/**
@@ -52,11 +52,11 @@ public class GemfireCqSourceProperties {
 		this.query = query;
 	}
 
-	public Expression getCqEventExpression() {
-		return cqEventExpression;
+	public Expression getEventExpression() {
+		return eventExpression;
 	}
 
-	public void setCqEventExpression(Expression cqEventExpression) {
-		this.cqEventExpression = cqEventExpression;
+	public void setEventExpression(Expression eventExpression) {
+		this.eventExpression = eventExpression;
 	}
 }

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
@@ -1,4 +1,5 @@
 configuration-properties.classes=org.springframework.cloud.stream.app.gemfire.cq.source.GemfireCqSourceProperties, \
   org.springframework.cloud.stream.app.gemfire.config.GemfirePoolProperties, \
   org.springframework.cloud.stream.app.gemfire.config.GemfireSecurityProperties, \
-  org.springframework.cloud.stream.app.gemfire.config.GemfireSslProperties
+  org.springframework.cloud.stream.app.gemfire.config.GemfireSslProperties, \
+  org.springframework.cloud.stream.app.gemfire.config.GemfireClientCacheProperties

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,4 +1,5 @@
 configuration-properties.classes=org.springframework.cloud.stream.app.gemfire.cq.source.GemfireCqSourceProperties, \
   org.springframework.cloud.stream.app.gemfire.config.GemfirePoolProperties, \
   org.springframework.cloud.stream.app.gemfire.config.GemfireSecurityProperties, \
-  org.springframework.cloud.stream.app.gemfire.config.GemfireSslProperties
+  org.springframework.cloud.stream.app.gemfire.config.GemfireSslProperties, \
+  org.springframework.cloud.stream.app.gemfire.config.GemfireClientCacheProperties

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/test/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfigurationTests.java
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/test/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfigurationTests.java
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  **/
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = { GemfireCqSourceConfigurationTests.TestConfig.class }, properties = {
-		"gemfire.query= Select * from /Stocks",
+		"gemfire.cq.query= Select * from /Stocks",
 		"gemfire.security.username=user",
 		"gemfire.security.password=password"})
 public class GemfireCqSourceConfigurationTests {

--- a/spring-cloud-starter-stream-source-gemfire/README.adoc
+++ b/spring-cloud-starter-stream-source-gemfire/README.adoc
@@ -29,7 +29,7 @@ N/A
 The **$$gemfire$$** $$source$$ supports the following configuration properties:
 
 //tag::configuration-properties[]
-$$gemfire.cache-event-expression$$:: $$SpEL expression to extract fields from a cache event.$$ *($$Expression$$, default: `$$<none>$$`)*
+$$gemfire.client.pdx-read-serialized$$:: $$Deserialize the Geode objects into PdxInstance instead of the domain class.$$ *($$Boolean$$, default: `$$false$$`)*
 $$gemfire.pool.connect-type$$:: $$Specifies connection type: 'server' or 'locator'.$$ *($$ConnectType$$, default: `$$<none>$$`, possible values: `locator`,`server`)*
 $$gemfire.pool.host-addresses$$:: $$Specifies one or more Gemfire locator or server addresses formatted as [host]:[port].$$ *($$InetSocketAddress[]$$, default: `$$<none>$$`)*
 $$gemfire.pool.subscription-enabled$$:: $$Set to true to enable subscriptions for the client pool. Required to sync updates to the client cache.$$ *($$Boolean$$, default: `$$false$$`)*
@@ -44,6 +44,7 @@ $$gemfire.security.ssl.truststore-type$$:: $$Identifies the type of truststore u
 $$gemfire.security.ssl.truststore-uri$$:: $$Location of the pre-created truststore URI to be used for connecting to the Geode cluster.$$ *($$Resource$$, default: `$$<none>$$`)*
 $$gemfire.security.ssl.user-home-directory$$:: $$Local directory to cache the truststore and keystore files downloaded form the truststoreUri and keystoreUri locations.$$ *($$String$$, default: `$$user.home$$`)*
 $$gemfire.security.username$$:: $$The cache username.$$ *($$String$$, default: `$$<none>$$`)*
+$$gemfire.source.cache-event-expression$$:: $$SpEL expression to extract fields from a cache event.$$ *($$Expression$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 == Build
@@ -61,7 +62,7 @@ $ ./mvnw clean package
 == Examples
 
 ```
-java -jar ./gemfire-source.jar --gemfire.region.region-name=MyRegion --gemfire.cacheEventExpression="newValue"
+java -jar ./gemfire-source.jar --gemfire.region.region-name=MyRegion --gemfire.source.cacheEventExpression="newValue"
 ```
 
 //end::ref-doc[]

--- a/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceProperties.java
+++ b/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,7 +24,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  *
  * @author David Turanski
  */
-@ConfigurationProperties("gemfire")
+@ConfigurationProperties("gemfire.source")
 public class GemfireSourceProperties {
 
 	private static final String DEFAULT_EXPRESSION = "newValue";

--- a/spring-cloud-starter-stream-source-gemfire/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-gemfire/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
@@ -2,4 +2,5 @@ configuration-properties.classes=org.springframework.cloud.stream.app.gemfire.so
   org.springframework.cloud.stream.app.gemfire.config.GemfireRegionProperties, \
   org.springframework.cloud.stream.app.gemfire.config.GemfirePoolProperties, \
   org.springframework.cloud.stream.app.gemfire.config.GemfireSecurityProperties, \
-  org.springframework.cloud.stream.app.gemfire.config.GemfireSslProperties
+  org.springframework.cloud.stream.app.gemfire.config.GemfireSslProperties, \
+  org.springframework.cloud.stream.app.gemfire.config.GemfireClientCacheProperties

--- a/spring-cloud-starter-stream-source-gemfire/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-gemfire/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -2,4 +2,5 @@ configuration-properties.classes=org.springframework.cloud.stream.app.gemfire.so
   org.springframework.cloud.stream.app.gemfire.config.GemfireRegionProperties, \
   org.springframework.cloud.stream.app.gemfire.config.GemfirePoolProperties, \
   org.springframework.cloud.stream.app.gemfire.config.GemfireSecurityProperties, \
-  org.springframework.cloud.stream.app.gemfire.config.GemfireSslProperties
+  org.springframework.cloud.stream.app.gemfire.config.GemfireSslProperties, \
+  org.springframework.cloud.stream.app.gemfire.config.GemfireClientCacheProperties


### PR DESCRIPTION
  - Add new property gemfire.client.pdxReadSerialized (in GemfireClicentCacheProperties ) to enable pdx read serializable - e.g. allow deserializing the input into PdxInstnce rather then Domain classes.
  - Change the GemfireCqSourceProperties prefix from gemfire to gemfire.cq (to avoid collisions with GEMFIRE env. variable)
  - Change the GemfireSourceProperties prefix from gemfire to gemfire.source (to avoid collisions with GEMFIRE env. variable)
  - update SDG to 2.1.5.RELEASE (Apache Geode 1.6 and Gemfire 9.5.x compatible)
  - update spring-integration to 5.1.3.RELEASE

  Resolves #28