### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessConfiguration.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessExecutor.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessInputStreamListener.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessInputStreamListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessWrapper.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ProcessWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ServerProcess.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/ServerProcess.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/PidUnavailableException.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/PidUnavailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/ProcessUtils.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/process/support/ProcessUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/FileSystemUtils.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/FileSystemUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/IOUtils.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/IOUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/ThreadUtils.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/ThreadUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/ThrowableUtils.java
+++ b/gemfire-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/gemfire/support/ThrowableUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/JsonObjectTransformer.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/JsonObjectTransformer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientCacheConfiguration.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientCacheConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientRegionConfiguration.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireClientRegionConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolConfiguration.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolProperties.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfirePoolProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireRegionProperties.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireRegionProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireSecurityProperties.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/GemfireSecurityProperties.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/InetSocketAddressConverterConfiguration.java
+++ b/spring-cloud-starter-stream-common-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/config/InetSocketAddressConverterConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkHandler.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkHandler.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfigurationTests.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkConfigurationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/sink/GemfireSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceProperties.java
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/main/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/test/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfigurationTests.java
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/test/java/org/springframework/cloud/stream/app/gemfire/cq/source/GemfireCqSourceConfigurationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceProperties.java
+++ b/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/KeyInterestConfiguration.java
+++ b/spring-cloud-starter-stream-source-gemfire/src/main/java/org/springframework/cloud/stream/app/gemfire/source/KeyInterestConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfigurationTests.java
+++ b/spring-cloud-starter-stream-source-gemfire/src/test/java/org/springframework/cloud/stream/app/gemfire/source/GemfireSourceConfigurationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *          https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 32 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).