### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-starter-stream-sink-gemfire/src/test/resources/gemfire-server.xml
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/resources/gemfire-server.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<util:properties id="gemfireProperties">
 		<prop key="name">TestServer</prop>

--- a/spring-cloud-starter-stream-sink-gemfire/src/test/resources/ssl-gemfire-server.xml
+++ b/spring-cloud-starter-stream-sink-gemfire/src/test/resources/ssl-gemfire-server.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/spring-cloud-starter-stream-source-gemfire-cq/src/test/resources/gemfire-server.xml
+++ b/spring-cloud-starter-stream-source-gemfire-cq/src/test/resources/gemfire-server.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/spring-cloud-starter-stream-source-gemfire/src/test/resources/gemfire-server.xml
+++ b/spring-cloud-starter-stream-source-gemfire/src/test/resources/gemfire-server.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/geode/spring-geode.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/geode/spring-geode.xsd ([https](https://www.springframework.org/schema/geode/spring-geode.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 14 occurrences
* http://www.springframework.org/schema/beans with 8 occurrences
* http://www.springframework.org/schema/geode with 8 occurrences
* http://www.springframework.org/schema/util with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 11 occurrences